### PR TITLE
Use RefreshControl instead of own implementation for pull-to-refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,15 +83,12 @@ var Example = React.createClass({
           refreshable={true} // enable pull-to-refresh for iOS and touch-to-refresh for Android
           withSections={false} // enable sections
           customStyles={{
-            refreshableView: {
+            paginationView: {
               backgroundColor: '#eee',
             },
           }}
 
-          PullToRefreshViewAndroidProps={{
-            colors: ['#ff0000', '#00ff00', '#0000ff'],
-            progressBackgroundColor: '#c8c7cc',
-          }}
+          refreshableTintColor="blue"
         />
       </View>
     );


### PR DESCRIPTION
Some advantages are:
- Less hacks in codebase
- React Native will handle the cross platform implementation, not this package
- Very nice animations
- `PullToRefreshViewAndroid` is deprecated as of RN 0.22, `RefreshControl` isn't

If you're fine with this I will also update the advanced example (simple example should still work).
