### PR TITLE
Add `refresh` and `paginate` options to indicate actions that trigger refreshing

### DIFF
--- a/GiftedListView.js
+++ b/GiftedListView.js
@@ -208,7 +208,7 @@ var GiftedListView = React.createClass({
     this._onRefresh({external: true});
   },
 
-  _onRefresh(options = {}) {
+  _onRefresh(options = {refresh: true}) {
     if (this.isMounted()) {
       this.setState({
         isRefreshing: true,
@@ -231,7 +231,7 @@ var GiftedListView = React.createClass({
       this.setState({
         paginationStatus: 'fetching',
       });
-      this.props.onFetch(this._getPage() + 1, this._postPaginate, {});
+      this.props.onFetch(this._getPage() + 1, this._postPaginate, {paginate: true});
     }
   },
 

--- a/GiftedListView.js
+++ b/GiftedListView.js
@@ -252,7 +252,7 @@ var GiftedListView = React.createClass({
     if(this.props.distinctRows){
       mergedRows = this.props.distinctRows(mergedRows);
     }
-    
+
     this._updateRows(mergedRows, options);
   },
 
@@ -305,6 +305,7 @@ var GiftedListView = React.createClass({
         colors={this.props.refreshableColors}
         progressBackgroundColor={this.props.refreshableProgressBackgroundColor}
         size={this.props.refreshableSize}
+        style={this.props.refreshableStyle}
         tintColor={this.props.refreshableTintColor}
         title={this.props.refreshableTitle}
       />

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ var Example = React.createClass({
    * Should be replaced by your own logic
    * @param {number} page Requested page to fetch
    * @param {function} callback Should pass the rows
-   * @param {object} options Inform if first load
+   * @param {object} options indicates different actions that trigger refreshing
+   *        options: [firstLoad || refresh || paginate || allLoaded]
    */
   _onFetch(page = 1, callback, options) {
     setTimeout(() => {
@@ -42,7 +43,7 @@ var Example = React.createClass({
       if (page === 3) {
         callback(rows, {
           allLoaded: true, // the end of the list is reached
-        });        
+        });
       } else {
         callback(rows);
       }
@@ -68,7 +69,7 @@ var Example = React.createClass({
         style={styles.row}
         underlayColor='#c8c7cc'
         onPress={() => this._onPress(rowData)}
-      >  
+      >
         <Text>{rowData}</Text>
       </TouchableHighlight>
     );

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   },
   "homepage": "https://github.com/FaridSafi/react-native-gifted-listview#readme",
   "dependencies": {
-    "react-native-gifted-spinner": "^0.0.4"
+    "react-native-gifted-spinner": "git+https://github.com/mdluo/react-native-gifted-spinner.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-native-gifted-listview",
-  "version": "0.0.15",
+  "name": "@mdluo/react-native-gifted-listview",
+  "version": "0.0.16",
   "description": "A ListView with pull-to-refresh, infinite scrolling and more for Android and iOS React-Native apps",
   "main": "GiftedListView.js",
   "scripts": {
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/FaridSafi/react-native-gifted-listview.git"
+    "url": "git+https://github.com/mdluo/react-native-gifted-listview.git"
   },
   "keywords": [
     "pull-to-refresh",
@@ -23,9 +23,9 @@
   "author": "Farid from Safi",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/FaridSafi/react-native-gifted-listview/issues"
+    "url": "https://github.com/mdluo/react-native-gifted-listview/issues"
   },
-  "homepage": "https://github.com/FaridSafi/react-native-gifted-listview#readme",
+  "homepage": "https://github.com/mdluo/react-native-gifted-listview#readme",
   "dependencies": {
     "react-native-gifted-spinner": "git+https://github.com/mdluo/react-native-gifted-spinner.git"
   }


### PR DESCRIPTION
Add `refresh` and `paginate` options to indicate actions that trigger refreshing

`onFetch` sometimes needs to be informed the type of actions to load
different data:

`refresh`: Pull to refresh action
`paginate`:  “Load more” was pressed
