### PR TITLE
Remove dependency for GiftedSpinner

### DIFF
--- a/GiftedListView.js
+++ b/GiftedListView.js
@@ -9,6 +9,7 @@ var {
   View,
   Text,
   RefreshControl,
+  ActivityIndicator
 } = require('react-native');
 
 
@@ -28,7 +29,6 @@ function MergeRecursive(obj1, obj2) {
   return obj1;
 }
 
-var GiftedSpinner = require('react-native-gifted-spinner');
 
 var GiftedListView = React.createClass({
 
@@ -102,7 +102,11 @@ var GiftedListView = React.createClass({
 
     return (
       <View style={[this.defaultStyles.paginationView, this.props.customStyles.paginationView]}>
-        <GiftedSpinner />
+        <ActivityIndicator
+          animating={true}
+          size="small"
+          {...this.props}
+        />
       </View>
     );
   },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   },
   "homepage": "https://github.com/FaridSafi/react-native-gifted-listview#readme",
   "dependencies": {
-    "react-native-gifted-spinner": "^0.0.4"
+    "react-native-gifted-spinner": "https://github.com/mcconkiee/react-native-gifted-spinner/tarball/master"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/FaridSafi/react-native-gifted-listview.git"
+    "url": "git+https://github.com/mcconkiee/react-native-gifted-listview.git"
   },
   "keywords": [
     "pull-to-refresh",
@@ -23,10 +23,7 @@
   "author": "Farid from Safi",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/FaridSafi/react-native-gifted-listview/issues"
+    "url": "https://github.com/mcconkiee/react-native-gifted-listview/issues"
   },
-  "homepage": "https://github.com/FaridSafi/react-native-gifted-listview#readme",
-  "dependencies": {
-    "react-native-gifted-spinner": "https://github.com/mcconkiee/react-native-gifted-spinner/tarball/master"
-  }
+  "homepage": "https://github.com/mcconkiee/react-native-gifted-listview#readme"  
 }


### PR DESCRIPTION
React Native >=0.28.0 begins depreciation for `ProgressBarAndroid` in favor of `ActivityIndicator`. This request removes the dependency for GiftedSpinner and just adds the `ActivityIndicator`.
