### PR TITLE
react-native-gifted-spinner version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   },
   "homepage": "https://github.com/FaridSafi/react-native-gifted-listview#readme",
   "dependencies": {
-    "react-native-gifted-spinner": "^0.0.4"
+    "react-native-gifted-spinner": "0.1.0"
   }
 }


### PR DESCRIPTION
Hi, i think you need to update the version of react-native-gifted-spinner in order to get rid of the warning about ActivityIndicator :)
